### PR TITLE
Fix problems with spaces in directories

### DIFF
--- a/functions/marlin:complete.fish
+++ b/functions/marlin:complete.fish
@@ -5,7 +5,7 @@ function marlin:complete
   set -l expansions (marlin:find $patterns)
 
   if set -q expansions[1]
-    echo -ns $expansions\n
+    echo -ns $expansions\n | string escape
     return 0
   end
 

--- a/functions/marlin:find.fish
+++ b/functions/marlin:find.fish
@@ -1,7 +1,7 @@
 function marlin:find -d 'Find all directories matching patterns in frecency order'
   echo -ns $argv\n | read -z -l -x marlin_patterns
 
-  command awk '
+  command awk -F'\t' '
     BEGIN {
       # Read search patterns from Fish.
       split(tolower(ENVIRON["marlin_patterns"]), patterns, "\n");
@@ -31,7 +31,7 @@ function marlin:find -d 'Find all directories matching patterns in frecency orde
     END {
       # Print out matching paths in order.
       for (i = 1; i <= NR; i++) {
-        sub(ENVIRON["HOME"], "~", paths[i]);
+        # sub(ENVIRON["HOME"], "~", paths[i]);
         print paths[i];
       }
     }

--- a/functions/marlin:log.fish
+++ b/functions/marlin:log.fish
@@ -7,14 +7,14 @@ function marlin:log -a path -d 'Record usage of a path'
     or echo -n > $MARLIN_HISTORY
 
   # Parse existing records, removing the record for the given path and inserting it at the end with an incremented score.
-  command awk '
+  command awk -F'\t' '
     {
       # If the current record matches the path we are logging, save it and move it to the end of file.
       if ($2 == ENVIRON["path"]) {
         score = $1;
       }
       # Before we pass through this record, check if the path still exists. If not, remove the record.
-      else if (!system("test -d " $2)) {
+      else if (0 == system(sprintf("test -d \"%s\"", $2))) {
         print $0;
       }
     }


### PR DESCRIPTION
This is tricky and maybe not the best solution, but two things: make sure awk uses tab as the FS, and also make sure that output is
escaped. This also fixes another bug that was arbitrarily changing anything that matches $HOME with "~".